### PR TITLE
fix: package naming for image / chart

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -140,7 +140,7 @@ jobs:
           min-versions-to-keep: 100
           delete-only-untagged-versions: "true"
 
-  build-and-deploy:
+  helm-build-and-deploy:
     needs: build-image
     runs-on: ubuntu-latest
     if: github.repository == 'taskmedia/helm_paperlessngx-ftp-bridge'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,7 +51,7 @@ jobs:
       # Use docker.io for Docker Hub if empty
       REGISTRY: ghcr.io
       # github.repository as <account>/<repo>
-      IMAGE_NAME: taskmedia/paperless-ftp-bridge
+      IMAGE_NAME: taskmedia/paperlessngx-ftp-bridge-image
 
     steps:
       - name: Checkout repository
@@ -106,11 +106,11 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: |
             ${{ steps.meta.outputs.tags }}
-            ghcr.io/taskmedia/paperless-ftp-bridge:latest
-            ghcr.io/taskmedia/paperless-ftp-bridge:${{ github.event.release.tag_name }}
-            fty4/paperless-ftp-bridge:main
-            fty4/paperless-ftp-bridge:latest
-            fty4/paperless-ftp-bridge:${{ github.event.release.tag_name }}
+            ghcr.io/taskmedia/paperlessngx-ftp-bridge-image:latest
+            ghcr.io/taskmedia/paperlessngx-ftp-bridge-image:${{ github.event.release.tag_name }}
+            fty4/paperlessngx-ftp-bridge-image:main
+            fty4/paperlessngx-ftp-bridge-image:latest
+            fty4/paperlessngx-ftp-bridge-image:${{ github.event.release.tag_name }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# ghcr.io/taskmedia/paperlessngx-ftp-bridge-image
 FROM golang:1.23-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./

--- a/charts/paperlessngx-ftp-bridge/Chart.yaml
+++ b/charts/paperlessngx-ftp-bridge/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: paperless-ngx-ftp-bridge
+name: paperlessngx-ftp-bridge
 description: A Helm chart to upload files to from a FTP (TLS) server to paperless-ngx
 home: https://helm.task.media/paperlessngx-ftp-bridge
 keywords:

--- a/charts/paperlessngx-ftp-bridge/values.yaml
+++ b/charts/paperlessngx-ftp-bridge/values.yaml
@@ -17,8 +17,8 @@ paperless:
 
 # image used for bridge
 image:
-  repository: ghcr.io/taskmedia/paperless-ftp-bridge
-  tag: main
+  repository: ghcr.io/taskmedia/paperlessngx-ftp-bridge-image
+  tag: ""
 
 # timeout for the job to complete backup
 activeDeadlineSeconds: 60


### PR DESCRIPTION
Ensure the correct and different name is used for both image and chart:

image: `paperlessngx-ftp-bridge-image`
chart: `paperlessngx-ftp-bridge`