### PR TITLE
chore: use the chart version as default image tag

### DIFF
--- a/charts/paperlessngx-ftp-bridge/templates/cronjob.yaml
+++ b/charts/paperlessngx-ftp-bridge/templates/cronjob.yaml
@@ -20,7 +20,7 @@ spec:
           serviceAccountName: {{ include "plngxftpbridge.fullname" . }}
           containers:
             - name: backup
-              image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+              image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.Version }}
               env:
                 - name: FTP_HOST
                   value: "{{ .Values.ftp.host }}"


### PR DESCRIPTION
chart should match with release version

empty tag was already set in #4 (`tag: ""`)