### PR TITLE
fix: remove usage of service account

### DIFF
--- a/charts/paperlessngx-ftp-bridge/templates/cronjob.yaml
+++ b/charts/paperlessngx-ftp-bridge/templates/cronjob.yaml
@@ -17,7 +17,6 @@ spec:
           labels:
             app: "{{ include "plngxftpbridge.fullname" . }}"
         spec:
-          serviceAccountName: {{ include "plngxftpbridge.fullname" . }}
           containers:
             - name: backup
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.Version }}"


### PR DESCRIPTION
Not required - copy error from [paperlessngx-backup](https://github.com/taskmedia/helm_paperlessngx-backup)