### PR TITLE
fix: use v prefix in image.tag version

### DIFF
--- a/charts/paperlessngx-ftp-bridge/templates/cronjob.yaml
+++ b/charts/paperlessngx-ftp-bridge/templates/cronjob.yaml
@@ -20,7 +20,7 @@ spec:
           serviceAccountName: {{ include "plngxftpbridge.fullname" . }}
           containers:
             - name: backup
-              image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.Version }}"
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.Version) }}"
               env:
                 - name: FTP_HOST
                   value: "{{ .Values.ftp.host }}"


### PR DESCRIPTION
Require version tag in container image